### PR TITLE
Jules output

### DIFF
--- a/src/main/scala/io/septimalmind/baboon/translator/scl/ScCodecTestsTranslator.scala
+++ b/src/main/scala/io/septimalmind/baboon/translator/scl/ScCodecTestsTranslator.scala
@@ -24,6 +24,188 @@ object ScCodecTestsTranslator {
     domain: Domain,
     evo: BaboonEvolution,
   ) extends ScCodecTestsTranslator {
-    override def translate(definition: DomainMember.User, csRef: ScValue.ScType, srcRef: ScValue.ScType): Option[TextTree[ScValue]] = None
+    import ScValue.*
+    private val scTrue = Lit("true")
+    private val scFalse = Lit("false")
+
+    override def translate(
+      definition: DomainMember.User,
+      csRef: ScValue.ScType,
+      srcRef: ScValue.ScType,
+    ): Option[TextTree[ScValue]] = {
+      val isLatestVersion = domain.version == evo.latest
+
+      definition match {
+        case d if enquiries.hasForeignType(d, domain)                           => None
+        case d if enquiries.isRecursiveTypedef(d, domain)                       => None
+        case d if d.defn.isInstanceOf[io.septimalmind.baboon.typer.model.Typedef.NonDataTypedef] => None
+        case _ if !target.language.enableDeprecatedEncoders && !isLatestVersion => None
+        case _ =>
+          val testClassName = s"${srcRef.name}_Tests"
+          val testClass =
+            ScValue.Tree(
+              List(
+                ScValue.Line(s"class $testClassName extends $anyFunSuite {"),
+                ScValue.Line(s"  import ${srcRef.name}._"),
+                makeTest(definition, srcRef).indented(2),
+                ScValue.Line(s"}"),
+              )
+            )
+          Some(testClass)
+      }
+    }
+
+    private def makeTest(definition: DomainMember.User, srcRef: ScValue.ScType): TextTree[ScValue] = {
+      // TODO: implement makeFixture by adapting from CS and ScCodecFixtureTranslator
+      val fixture = makeFixture(definition, domain, evo)
+
+      val codecTests = codecs.map {
+        case jsonCodec: ScJsonCodecTranslator =>
+          val body = jsonCodecAssertions(jsonCodec, definition, srcRef)
+          ScValue.Tree(
+            List(
+              ScValue.Line(s"""test("json codec test for ${srcRef.name}") { """),
+              ScValue.Line(s"  for (i <- 0 until ${target.generic.codecTestIterations}) {"),
+              ScValue.Line(s"    jsonCodecTestImpl(${ScValue.baboonCodecContext}.Default)"),
+              ScValue.Line(s"  }"),
+              ScValue.Line(s"}"),
+              ScValue.Line(s""),
+              ScValue.Line(s"private def jsonCodecTestImpl(context: ${ScValue.baboonCodecContext}): Unit = {"),
+              fixture.indented(4),
+              body.indented(4),
+              ScValue.Line(s"}"),
+            )
+          )
+        case uebaCodec: ScUebaCodecTranslator =>
+          val body = uebaCodecAssertions(uebaCodec, definition, srcRef)
+          ScValue.Tree(
+            List(
+              ScValue.Line(s"""test("ueba codec test (no index) for ${srcRef.name}") { """),
+              ScValue.Line(s"  for (i <- 0 until ${target.generic.codecTestIterations}) {"),
+              ScValue.Line(s"    uebaCodecTestImpl(${ScValue.baboonCodecContext}.Compact)"),
+              ScValue.Line(s"  }"),
+              ScValue.Line(s"}"),
+              ScValue.Line(s""),
+              ScValue.Line(s"""test("ueba codec test (indexed) for ${srcRef.name}") { """),
+              ScValue.Line(s"  for (i <- 0 until ${target.generic.codecTestIterations}) {"),
+              ScValue.Line(s"    uebaCodecTestImpl(${ScValue.baboonCodecContext}.Indexed)"),
+              ScValue.Line(s"  }"),
+              ScValue.Line(s"}"),
+              ScValue.Line(s""),
+              ScValue.Line(s"private def uebaCodecTestImpl(context: ${ScValue.baboonCodecContext}): Unit = {"),
+              fixture.indented(4),
+              body.indented(4),
+              ScValue.Line(s"}"),
+            )
+          )
+        case unknown =>
+          logger.message(s"Cannot create codec tests (${unknown.codecName(srcRef)}) for unsupported type $srcRef")
+          ScValue.Empty
+      }.toList
+
+      ScValue.Tree(codecTests.filterNot(_.isEmpty))
+    }
+
+    private def makeFixture(
+      definition: DomainMember.User,
+      domain: Domain,
+      evolution: BaboonEvolution,
+    ): TextTree[ScValue] = {
+      definition.defn match {
+        case e: io.septimalmind.baboon.typer.model.Typedef.Enum =>
+          // Enums are handled directly by BaboonRandom in ScCodecFixtureTranslator as well
+          val enumType = typeTranslator.asScType(e.id, domain, evolution)
+          Line(s"val fixture = $baboonRandom.nextRandomEnum[${enumType.name}]()")
+        case adt: io.septimalmind.baboon.typer.model.Typedef.Adt =>
+          val fixtureObject = s"${typeTranslator.asScType(adt.id, domain, evolution).name}_Fixture"
+          Line(s"val fixtures = $fixtureObject.randomAll($baboonRandom)")
+        case dto: io.septimalmind.baboon.typer.model.Typedef.Dto =>
+          val fixtureObject = s"${typeTranslator.asScType(dto.id, domain, evolution).name}_Fixture"
+          Line(s"val fixture = $fixtureObject.random($baboonRandom)")
+        case other => // Should ideally not happen if initial checks are correct
+          logger.warn(s"makeFixture called with unexpected definition type: $other for ${definition.id.name.name}")
+          Empty
+      }
+    }
+
+    private def jsonCodecAssertions(
+      codec: ScJsonCodecTranslator,
+      definition: DomainMember.User,
+      srcRef: ScValue.ScType
+    ): TextTree[ScValue] = {
+      // TODO: Implement Scala specific JSON assertions
+      def jsonTest(isAdtMember: Boolean): TextTree[ScValue] = {
+        val codecName = codec.codecName(srcRef)
+        val fieldName = if (isAdtMember) "adtMemberFixture" else "fixture"
+        val serialized = ScValue.L(s"${fieldName}Json")
+        val decoded = ScValue.L(s"${fieldName}Decoded")
+        ScValue.Tree(
+          List(
+            ScValue.Line(s"val $serialized = $codecName.encode(context, $fieldName)"),
+            ScValue.Line(s"val $decoded = $codecName.decode(context, $serialized)"),
+            ScValue.Line(s"assert($fieldName == $decoded)"),
+          )
+        )
+      }
+
+      definition.defn match {
+        case _: io.septimalmind.baboon.typer.model.Typedef.Adt =>
+          ScValue.Tree(
+            List(
+              ScValue.Line(s"fixtures.foreach { adtMemberFixture => "),
+              jsonTest(true).indented(2),
+              ScValue.Line(s"}"),
+            )
+          )
+        case _ =>
+          jsonTest(false)
+      }
+    }
+
+    private def uebaCodecAssertions(
+      codec: ScUebaCodecTranslator,
+      definition: DomainMember.User,
+      srcRef: ScValue.ScType
+    ): TextTree[ScValue] = {
+      // TODO: Implement Scala specific UEBA assertions
+      // This will involve using something like ByteArrayInputStream/OutputStream and DataInputStream/OutputStream
+      def binaryTest(isAdtMember: Boolean): TextTree[ScValue] = {
+        val codecName = codec.codecName(srcRef)
+        val fieldName = if (isAdtMember) "adtMemberFixture" else "fixture"
+        val serialized = ScValue.L(s"${fieldName}Bytes")
+        val decoded = ScValue.L(s"${fieldName}Decoded")
+
+        ScValue.Tree(
+          List(
+            ScValue.Line(s"val baos = new java.io.ByteArrayOutputStream()"),
+            ScValue.Line(s"val dos = new java.io.DataOutputStream(baos)"),
+            ScValue.Line(s"$codecName.encode(context, dos, $fieldName)"),
+            ScValue.Line(s"dos.flush()"),
+            ScValue.Line(s"val $serialized = baos.toByteArray()"),
+            ScValue.Line(s"val bais = new java.io.ByteArrayInputStream($serialized)"),
+            ScValue.Line(s"val dis = new java.io.DataInputStream(bais)"),
+            ScValue.Line(s"val $decoded = $codecName.decode(context, dis)"),
+            ScValue.Line(s"assert($fieldName == $decoded)"),
+          )
+        )
+      }
+
+      definition.defn match {
+        case _: io.septimalmind.baboon.typer.model.Typedef.Adt =>
+          ScValue.Tree(
+            List(
+              ScValue.Line(s"fixtures.foreach { adtMemberFixture => "),
+              binaryTest(true).indented(2),
+              ScValue.Line(s"}"),
+            )
+          )
+        case _ =>
+          binaryTest(false)
+      }
+    }
+
+    private def anyFunSuite = tpe("org.scalatest.funsuite.AnyFunSuite")
+    private def baboonRandom = ScValue.baboonRandom
+    private def baboonCodecContext = ScValue.baboonCodecContext
   }
 }

--- a/test/sc-stub/baboon-defs/sc_codec_test_defs.baboon
+++ b/test/sc-stub/baboon-defs/sc_codec_test_defs.baboon
@@ -1,0 +1,52 @@
+model scstub.codectests
+
+version "1.0.0"
+
+root enum MyTestEnum {
+    ALPHA
+    BETA
+    GAMMA
+}
+
+root data MyTestDto {
+    fieldStr: str
+    fieldI08: i08
+    fieldI16: i16
+    fieldI32: i32
+    fieldI64: i64
+    fieldU08: u08
+    fieldU16: u16
+    fieldU32: u32
+    fieldU64: u64
+    fieldF32: f32
+    fieldF64: f64
+    // fieldF128: f128 // Depending on support
+    fieldBool: bit
+    fieldUid: uid
+    fieldTsu: tsu
+    fieldTso: tso
+
+    optField: opt[str]
+    listField: lst[MyTestEnum]
+    mapField: map[str, i32]
+}
+
+root adt MyTestAdt {
+    BranchA {
+        valueA: str
+    }
+    BranchB {
+        valueB: i32
+        common: opt[MyTestEnum]
+    }
+}
+
+// A DTO that includes the ADT and Enum
+root data MyComplexDto {
+    id: uid
+    enumVal: MyTestEnum
+    adtVal: MyTestAdt
+    optAdtVal: opt[MyTestAdt]
+    listAdt: lst[MyTestAdt]
+    mapEnumToAdt: map[MyTestEnum, MyTestAdt]
+}

--- a/test/sc-stub/src/test/scala/io/septimalmind/baboon/scstub/GeneratedCodecTestsSpec.scala
+++ b/test/sc-stub/src/test/scala/io/septimalmind/baboon/scstub/GeneratedCodecTestsSpec.scala
@@ -1,0 +1,143 @@
+package io.septimalmind.baboon.scstub
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.wordspec.AnyWordSpec
+import java.nio.file.{Files, Paths}
+
+class GeneratedCodecTestsSpec extends AnyWordSpec {
+
+  // Define the expected output directory for generated test files.
+  // This path will need to be adjusted based on the actual generator's output structure.
+  // Assuming the generator outputs to a path like:
+  // target/scala-2.13/src_managed/test/scstub/codectests/
+  // The exact path depends on sbt-buildinfo or other plugins if used by the main Baboon build.
+  // For now, let's make it relative to a hypothetical "generated-sources" root.
+  val generatedTestSourcesBaseDir = Paths.get("target/baboon/generated-test-sources/scstub/codectests") // Placeholder
+
+  // List of expected generated test files based on sc_codec_test_defs.baboon
+  val expectedTestFiles = Seq(
+    "MyTestEnum_Tests.scala",
+    "MyTestDto_Tests.scala",
+    "MyTestAdt_Tests.scala",
+    "MyComplexDto_Tests.scala"
+    // Note: ADT members (BranchA, BranchB) might also have their own _Tests.scala files
+    // if they are treated as independent definitions by the test generator.
+    // For now, assuming only root definitions get test files.
+    // If MyTestAdt.BranchA and MyTestAdt.BranchB are generated as top-level like classes,
+    // they might also have tests:
+    // "BranchA_Tests.scala",
+    // "BranchB_Tests.scala"
+    // This depends on how ScDefnTranslator and ScCodecTestsTranslator handle ADT members.
+    // Based on ScDefnTranslator logic, ADT members are usually part of the ADT's file or not generated standalone.
+    // The CSDefnTranslator skips ADT members if `useCompactAdtForm` is true.
+    // ScDefnTranslator skips Owner.Adt(_) for translateTests.
+    // So, likely no separate files for BranchA, BranchB.
+  )
+
+  "Generated Codec Tests" should {
+    "exist in the expected output directory" in {
+      // This is a placeholder for where the Baboon compiler would be invoked.
+      // In a real build, this would happen before tests run.
+      // For this subtask, we are just checking for pre-generated files.
+
+      var allFilesFound = true
+      val missingFiles = scala.collection.mutable.ListBuffer[String]()
+
+      expectedTestFiles.foreach { fileName =>
+        val filePath = generatedTestSourcesBaseDir.resolve(fileName)
+        if (!Files.exists(filePath)) {
+          allFilesFound = false
+          missingFiles += filePath.toString
+          println(s"Missing expected generated test file: $filePath")
+        } else {
+          println(s"Found expected generated test file: $filePath")
+        }
+      }
+
+      if (!allFilesFound) {
+        fail(s"Missing generated test files: ${missingFiles.mkString(", ")}")
+      }
+    }
+
+    // Advanced: Placeholder for a test that tries to compile generated files
+    // "compile successfully" in {
+    //   // This would require:
+    //   // 1. Knowing the exact output paths of generated files.
+    //   // 2. Invoking the Scala compiler (e.g., via sbt, or programmatically).
+    //   // 3. Checking for compilation errors.
+    //   // This is likely too complex for the current subtask.
+    //   succeed // Placeholder
+    // }
+  }
+}
+package io.septimalmind.baboon.scstub
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.wordspec.AnyWordSpec
+import java.nio.file.{Files, Paths}
+
+class GeneratedCodecTestsSpec extends AnyWordSpec {
+
+  // Define the expected output directory for generated test files.
+  // This path will need to be adjusted based on the actual generator's output structure.
+  // Assuming the generator outputs to a path like:
+  // target/scala-2.13/src_managed/test/scstub/codectests/
+  // The exact path depends on sbt-buildinfo or other plugins if used by the main Baboon build.
+  // For now, let's make it relative to a hypothetical "generated-sources" root.
+  // The actual path for ScDefnTranslator output is like:
+  // s"$fbase/${defn.id.name.name.capitalize}${suffix.getOrElse("")}.scala"
+  // where fbase is like "baboon-out/version/domain/subdomain"
+  // and suffix is ".tests"
+  // So, for model scstub.codectests, version 1.0.0, it would be something like:
+  // baboon-out/1.0.0/scstub/codectests/MyTestEnum.tests.scala
+  // Let's adjust the base directory accordingly.
+  val generatedTestSourcesBaseDir = Paths.get("baboon-out/1.0.0/scstub/codectests")
+
+
+  // List of expected generated test files based on sc_codec_test_defs.baboon
+  // Filenames are based on ScDefnTranslator.getOutputPath
+  val expectedTestFiles = Seq(
+    "MyTestEnum.tests.scala",
+    "MyTestDto.tests.scala",
+    "MyTestAdt.tests.scala",
+    "MyComplexDto.tests.scala"
+    // ADT members (BranchA, BranchB) are part of the ADT definition file in Scala,
+    // and ScDefnTranslator.translateTests filters out Owner.Adt members,
+    // so they won't have their own separate test files.
+  )
+
+  "Generated Codec Test files" should {
+    "exist in the expected output directory after Baboon compilation" in {
+      // Note: This test assumes that the Baboon compilation process has already run
+      // and generated the test files. In a typical sbt setup, code generation
+      // would be a task that runs before the `test` task.
+
+      var allFilesFound = true
+      val missingFiles = scala.collection.mutable.ListBuffer[String]()
+
+      expectedTestFiles.foreach { fileName =>
+        val filePath = generatedTestSourcesBaseDir.resolve(fileName)
+        if (!Files.exists(filePath)) {
+          allFilesFound = false
+          missingFiles += filePath.toString
+          System.err.println(s"Missing expected generated test file: $filePath")
+        } else {
+          System.out.println(s"Found expected generated test file: $filePath")
+        }
+      }
+
+      if (!allFilesFound) {
+        fail(s"Missing generated test files: ${missingFiles.mkString(", ")}. " +
+             s"Please ensure Baboon compiler has run and generated test files to '${generatedTestSourcesBaseDir.toAbsolutePath}'.")
+      }
+    }
+
+    // TODO: Add a test to check if the generated test files can be compiled.
+    // This would typically be covered by the sbt build process itself if the
+    // generated files are part of the sbt test sources.
+    // If sbt includes `generatedTestSourcesBaseDir` in `Test / sourceDirectories`,
+    // then `sbt test` would compile them.
+    // A specific test here could try to invoke scalac programmatically if needed,
+    // but that's more involved.
+  }
+}


### PR DESCRIPTION
This update introduces the implementation for the Scala codec test generator.

Key changes include:
- I've implemented the logic to generate ScalaTest-based tests for Baboon-defined types (enums, ADTs, DTOs). This is adapted from the existing C# test generator.
- The generated tests cover JSON and UEBA codecs, including assertions for encode/decode cycles.
- I've implemented fixture generation logic for Scala tests to provide test data.
- I've verified that the `ScDefnTranslator` correctly integrates the call to the new test generation logic.
- I've added new Baboon definition files (`test/sc-stub/baboon-defs/sc_codec_test_defs.baboon`) with a variety of types to serve as input for testing the generator.
- I've added a ScalaTest specification (`test/sc-stub/src/test/scala/io/septimalmind/baboon/scstub/GeneratedCodecTestsSpec.scala`) that checks for the existence of the generated test files.

The new generator allows for automated testing of Scala codecs produced by Baboon, improving the robustness of the Scala translation.